### PR TITLE
make explicit: deploy model after endpoint created

### DIFF
--- a/src/ml/pipeline.py
+++ b/src/ml/pipeline.py
@@ -77,7 +77,7 @@ def pipeline(
         display_name="bootkon-endpoint",
     )
 
-    ModelDeployOp(
+    model_deploy_op = ModelDeployOp(
         endpoint=endpoint_create_op.outputs["endpoint"],
         model=model_upload_op.outputs["model"],
         deployed_model_display_name="bootkon-endpoint",
@@ -85,6 +85,7 @@ def pipeline(
         dedicated_resources_min_replica_count=1,
         dedicated_resources_max_replica_count=1
     )
+    model_deploy_op.after(endpoint_create_op)
 
 
 compiler.Compiler().compile(


### PR DESCRIPTION
Endpoint creation failed with the first run of `pipeline.py` in testing. I succeeded when I re-ran with this change to make the ordering explicit (although both pipeline run graphs show the same dependencies). 

It may be worth testing to verify that this leads to success on the first run, without any existing components already deployed from previous run attempts.